### PR TITLE
Add responsive stylig fix to home button for mobile view

### DIFF
--- a/src/Header/Header.css
+++ b/src/Header/Header.css
@@ -37,16 +37,16 @@
 @media screen and (max-width: 500px) {
  .header {
    flex-direction: column;
-     padding: 1px 30px;
+   justify-content: center; 
+   height: 155px; 
   }
 
   .header-title {
-    font-size: 1.55em;
+    font-size: 1.7em;
     text-align: center;
   }
 
   .home-btn {
-    margin-bottom: 0px;
     padding: 8px 30px;
   }
 }


### PR DESCRIPTION
## Purpose
- when home button was changed to a Link it lost it's responsive styling
- this fixes the home button on mobile view to stay inside the header bar
## Approach
- height was added to the header bar, and the content was centered
#### Open Questions and Pre-Merge TODOs
- [x] test mobile implementation to see if layout looks fine
## Learning
- unsure why the home button is not staying within the header bar, it seems to not be acting as a flex child. Wondering if it has something to do with the anchor tag

